### PR TITLE
Add MemClaw to memory tools table

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,7 @@ Please open a pull request
 | NebulaGraph                   | https://www.nebula-graph.io/             | Open source        | https://github.com/vesoft-inc/nebula            | Storage         | Graph         |
 | Vanna.AI                          | https://vanna.ai/                       | Open source        | https://github.com/vanna-ai/vanna            | Memory Tool         | Vector        |
 | Neon                          | https://neon.tech/                       | Open source        | https://github.com/neondatabase/neon            | Storage         | Vector        |
+| MemClaw                        | https://memclaw.me                       | Open source        | https://github.com/Felo-Inc/memclaw             | Memory Tool     | Vector        |
 | WhyHowAI                      | https://www.whyhow.ai/                   | Closed             | https://github.com/whyhow-ai                    | Memory Tool     | Graph         |
 | Graphlit                      | https://graphlit.com                     | Closed             |                                                 | Memory Tool     | Graph, Vector |
 | ragie.ai                      | ragie.ai                                 | Closed             | https://github.com/ragieai                      | Memory Tool     | Vector        |


### PR DESCRIPTION
## Summary

- Adds [MemClaw](https://memclaw.me) to the memory tools table
- MemClaw is a persistent project memory tool for AI coding agents — it creates isolated memory workspaces per project with a web dashboard for reviewing and managing what the AI remembers
- Open source (MIT), free to use, GitHub: https://github.com/Felo-Inc/memclaw

## Why it belongs here

MemClaw fits the Memory Tool category alongside mem0, Zep, and Letta. Its key differentiator is **project-level memory isolation** — unlike general-purpose memory layers, each project gets its own memory workspace, preventing context bleed between tasks.