### PR TITLE
Update README: group tools by category, add descriptions and usage guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,21 +1,7 @@
-# awesome-ai-memory
+<h1 align="center"> Awesome AI Memory <p align="center"> <a href="https://discord.gg/tV7pr5XSj7" target="_blank"> <img src="https://img.shields.io/static/v1?label=Join&message=discord!&color=mediumslateblue"> </a> <a href="https://twitter.com/tricalt" target="_blank"> <img src="https://img.shields.io/twitter/follow/tricalt.svg?logo=twitter"> </a> </p> </h1> <h3 align="center"> Add <a href="https://github.com/topoteretes/cognee"> cognee</a> to your AI App </h3> <h5 align="center">🌟 <img src="assets/infographic_v7.png" width="100%" alt="Chart of AI Memory Landscape" /></h5>
 
 
-
-<h1 align="center"> Awesome AI Memory <p align="center"> <a href="https://discord.gg/tV7pr5XSj7" target="_blank"> <img src="https://img.shields.io/static/v1?label=Join&message=discord!&color=mediumslateblue"> </a> <a href="https://twitter.com/tricalt" target="_blank"> <img src="https://img.shields.io/twitter/follow/tricalt.svg?logo=twitter"> </a> </p> </h1> <h3 align="center"> Add <a href="https://github.com/topoteretes/cognee"> cognee</a> to your AI App </h3> <h5 align="center">🌟 <img src="assets/infographic_v7.png" width="100%" alt="Chart of AI Memory Landscape" />
-
-
-## Welcome to our curated list of AI memory tools
-You can see the projects split across various dimensions
-1. Open-source projects vs Closed-source projects and companies
-2. Graph, Vector, or Both
-3. Memory, Framework, Optimizer, or Storage
-
-
-There might be many more companies we are not aware of. Your feedback and contributions are appreciated! ❤️
-
-Have anything to add?
-Please open a pull request
+> A curated list of tools, frameworks, optimizers, and storage layers that give AI apps and agents memory.
 
 [Check out Cognee – A semantic memory for AI Apps and Agents](https://github.com/topoteretes/cognee)
 
@@ -23,57 +9,145 @@ Please open a pull request
 - **Contact us at [info@topoteretes.com](mailto:info@topoteretes.com) or join us on [Discord](https://discord.gg/m9KxxYWH)**
 - **Follow us on [Twitter](https://twitter.com/tricalt)**
 
+## Welcome to our curated list of AI memory tools
+You can see the projects split across various dimensions
+1. Open-source projects vs Closed-source projects and companies
+2. Graph, Vector, or Both
+3. Memory, Framework, Optimizer, or Storage
 
+Have anything to add? See the [Contributing](#contributing) section.
 
+## Contents
 
+- [How to use this list](#how-to-use-this-list)
+- [Types of AI memory](#types-of-ai-memory)
+- [Memory tools](#memory-tools)
+- [LLM frameworks](#llm-frameworks)
+- [Optimizers](#optimizers)
+- [Storage](#storage)
+- [Benchmarks & evaluation](#benchmarks--evaluation)
+- [Contributing](#contributing)
+- [Cite this list](#cite-this-list)
 
+## How to use this list
 
-| Name                          | URL                                      | Open / Close       | GitHub URL                                      | Category        | Storage       |
-|-------------------------------|------------------------------------------|--------------------|-------------------------------------------------|-----------------|---------------|
-| cognee                        | https://www.cognee.ai/                   | Managed, Open source | https://github.com/topoteretes/cognee         | Memory Tool     | Graph, Vector |
-| mem0 (mem zero)               | https://mem0.ai/                         | Managed, Open source | https://github.com/mem0ai/mem0                  | Memory Tool     | Graph, Vector |
-| MemClaw                       | https://memclaw.net/                     | Managed, Open source | https://github.com/caura-ai/caura-memclaw     | Memory Tool       | Graph, Vector |
-| Zep AI                        | https://www.getzep.com/                  | Managed, Open source | https://github.com/getzep/zep                   | Memory Tool     | Graph, Vector |
-| Mengram                       | https://mengram.io/                      | Managed, Open source | https://github.com/alibaizhanov/mengram         | Memory Tool     | Graph, Vector |
-| memonto                       |                                          | Open source        | https://github.com/shihanwan/memonto            | Memory Tool     | Graph         |
-| Memary                        | https://finetune.dev/                    | Open source        | https://github.com/kingjulio8238/Memary         | Memory Tool     | Graph         |
-| BaseAI (from Langbase) - Memory | https://langbase.com/docs/memory        | Managed, Open source | https://github.com/LangbaseInc/baseai           | Memory Tool     | Vector        |
-| BondAI                        | https://bondai.dev/docs/agent-memory/    | Open source        | https://github.com/krohling/bondai              | Memory Tool     | Vector        |
-| MemGPT (from Letta)           | https://memgpt.ai/                       | Managed, Open source | https://github.com/cpacker/MemGPT               | Memory Tool     | Graph, Vector |
-| GraphRAG (from Microsoft)     | https://microsoft.github.io/graphrag/    | Open source        | https://github.com/microsoft/graphrag           | Memory Tool     | Graph, Vector |
-| Llama index                   | https://www.llamaindex.ai/               | Managed, Open source | https://github.com/run-llama/llama_index        | LLM Framework   | Graph, Vector |
-| Prometheus                    | https://prometheus.io/                   | Open source        | https://github.com/prometheus                   | Memory Tool     | Graph         |
-| DSPy                          | https://dspy.ai/                         | Open source        | https://github.com/stanfordnlp/dspy             | Optimizer       | Vector        |
-| Neo4j                         | https://neo4j.com/                       | Managed, Open source | https://github.com/neo4j                        | Storage         | Graph         |
-| FalkorDB                      | https://www.falkordb.com/                | Open source          | https://github.com/FalkorDB/falkordb            | Storage         | Graph         |
-| HybridAGI                     | https://synalinks.github.io/documentation/ | Open source        | https://github.com/SynaLinks/HybridAGI          | Memory Tool     | Graph, Vector |
-| txtai                         | https://neuml.github.io/txtai/           | Open source        | https://github.com/neuml/txtai                  | Memory Tool     | Vector        |
-| chroma                        | https://www.trychroma.com/               | Open source        | https://github.com/chroma-core/chroma           | Storage         | Vector        |
-| LangChain                     | https://www.langchain.com/               | Open source        | https://github.com/langchain-ai/langchain       | LLM Framework   | Vector        |
-| Weaviate                      | weaviate.io                              | Open source        | github.com/weaviate/weaviate                    | Storage         | Vector        |
-| Milvus                        | milvus.io                                | Open source        | github.com/milvus-io/milvus                     | Storage         | Vector        |
-| Qdrant                        | qdrant.tech                              | Open source        | github.com/qdrant/qdrant                        | Storage         | Vector        |
-| Faiss                         | https://faiss.ai/                        | Open source        | github.com/facebookresearch/faiss               | Storage         | Vector        |
-| Elasticsearch                 | https://www.elastic.co/elasticsearch     | Open source        | https://github.com/elastic/elasticsearch        | Storage         | Vector        |
-| Jina AI                       | https://jina.ai/                         | Open source        | https://github.com/jina-ai                      | Optimizer       | Vector        |
-| Haystack                      | https://haystack.deepset.ai/             | Open source        | https://github.com/deepset-ai                   | LLM Framework   | Vector        |
-| PraisonAI                     | https://docs.praison.ai/                 | Open source        | https://github.com/MervinPraison/PraisonAI      | LLM Framework   | Graph, Vector |
-| Rasa                          | https://rasa.com/                        | Open source        | https://github.com/RasaHQ/                      | LLM Framework   | Graph, Vector |
-| NebulaGraph                   | https://www.nebula-graph.io/             | Open source        | https://github.com/vesoft-inc/nebula            | Storage         | Graph         |
-| Vanna.AI                          | https://vanna.ai/                       | Open source        | https://github.com/vanna-ai/vanna            | Memory Tool         | Vector        |
-| Neon                          | https://neon.tech/                       | Open source        | https://github.com/neondatabase/neon            | Storage         | Vector        |
-| MemClaw                        | https://memclaw.me                       | Open source        | https://github.com/Felo-Inc/memclaw             | Memory Tool     | Vector        |
-| WhyHowAI                      | https://www.whyhow.ai/                   | Closed             | https://github.com/whyhow-ai                    | Memory Tool     | Graph         |
-| Graphlit                      | https://graphlit.com                     | Closed             |                                                 | Memory Tool     | Graph, Vector |
-| ragie.ai                      | ragie.ai                                 | Closed             | https://github.com/ragieai                      | Memory Tool     | Vector        |
-| Ontotext                      | https://www.ontotext.com/                | Closed             | https://github.com/Ontotext-AD                  | Memory Tool     | Graph         |
-| SID                           | https://www.sid.ai/                      | Closed             |                                                 | Memory Tool     | Vector        |
-| vectara                       | https://www.vectara.com/                 | Closed             |                                                 | Storage         | Vector        |
-| arcus                         | arcus.co                                 | Closed             |                                                 | Storage         | Vector        |
-| Oxford Semantic Technologies  | https://www.oxfordsemantic.tech/         | Closed             |                                                 | Storage         | Graph         |
-| Prometheux                    | https://www.prometheux.co.uk/            | Closed             |                                                 | Memory Tool, Storage | Vector    |
-| Pinecone                      | pinecone.io                              | Closed             |                                                 | Storage         | Vector        |
-| AllegroGraph                  | https://allegrograph.com/                | Closed             |                                                 | Memory Tool     | Graph         |
-| StarDog                       | https://www.stardog.com/                 | Closed             |                                                 | Storage         | Graph         |
-| supabase                      | https://supabase.com/                    | Open source        | https://github.com/supabase                     | Storage         | Vector        |
-| llongterm                      | https://www.llongterm.com/                    | Closed       |                      | Memory Tool         | Graph         |
+Each project is tagged across three dimensions:
+
+| Column | Values | Meaning |
+|--------|--------|---------|
+| **Open / Close** | Open source · Managed · Closed | Whether you can self-host, and whether a hosted offering exists |
+| **Category** | Memory Tool · LLM Framework · Optimizer · Storage | Where it sits in the stack |
+| **Storage** | Graph · Vector · Graph, Vector | How it represents and retrieves memory |
+
+- **Memory Tool** — purpose-built to give agents persistent, retrievable memory.
+- **LLM Framework** — general agent/app frameworks that include a memory module.
+- **Optimizer** — improves retrieval, prompts, or embeddings rather than storing memory directly.
+- **Storage** — the underlying database (vector store or graph DB) a memory layer is built on.
+
+## Types of AI memory
+ 
+Most memory systems combine a few well-established kinds of memory:
+ 
+- **Short-term (working) memory** — transient context held within the model's context window for a single task or conversation.
+- **Long-term memory** — information persisted externally and retrieved across sessions. It's commonly broken down into:
+  - **Episodic** — specific past events and interactions ("what happened").
+  - **Semantic** — facts, preferences, and entities ("what is true").
+  - **Procedural** — reusable workflows and skills ("how to do something").
+Implementations differ mainly in how they store and retrieve this memory: **vector** search for semantic similarity, a **graph** for entities and relationships, or a **hybrid** of both (often with keyword/BM25 signals on top).
+
+## Memory tools
+
+| Name | Description | URL | Open / Close | GitHub URL | Category | Storage |
+|------|-------------|-----|--------------|------------|----------|---------|
+| cognee | Open-source AI memory platform for agents; builds a self-hosted knowledge graph with hybrid vector + graph retrieval via an ECL pipeline | https://www.cognee.ai/ | Managed, Open source | https://github.com/topoteretes/cognee | Memory Tool | Graph, Vector |
+| mem0 (mem zero) | Self-improving memory layer for AI agents and assistants | https://mem0.ai/ | Managed, Open source | https://github.com/mem0ai/mem0 | Memory Tool | Graph, Vector |
+| MemClaw | Governed, shared memory for multi-agent AI fleets (pgvector + graph + keyword) | https://memclaw.net/ | Managed, Open source | https://github.com/caura-ai/caura-memclaw | Memory Tool | Graph, Vector |
+| Zep AI | Memory layer for AI agents built on a temporal knowledge graph | https://www.getzep.com/ | Managed, Open source | https://github.com/getzep/zep | Memory Tool | Graph, Vector |
+| Mengram | Memory API with semantic, episodic, and procedural memory types | https://mengram.io/ | Managed, Open source | https://github.com/alibaizhanov/mengram | Memory Tool | Graph, Vector |
+| memonto | Long-term agent memory mapped onto a user-defined ontology / knowledge graph | | Open source | https://github.com/shihanwan/memonto | Memory Tool | Graph |
+| Memary | Open-source long-term memory for autonomous agents using a knowledge graph | https://finetune.dev/ | Open source | https://github.com/kingjulio8238/Memary | Memory Tool | Graph |
+| BaseAI (from Langbase) - Memory | Memory module of Langbase's open-source BaseAI framework for serverless AI agents | https://langbase.com/docs/memory | Managed, Open source | https://github.com/LangbaseInc/baseai | Memory Tool | Vector |
+| BondAI | Open-source AI agent framework with built-in vector memory | https://bondai.dev/docs/agent-memory/ | Open source | https://github.com/krohling/bondai | Memory Tool | Vector |
+| MemGPT (from Letta) | LLM "operating system" that manages memory beyond the context window | https://memgpt.ai/ | Managed, Open source | https://github.com/cpacker/MemGPT | Memory Tool | Graph, Vector |
+| GraphRAG (from Microsoft) | Graph-based RAG over knowledge graphs extracted by an LLM | https://microsoft.github.io/graphrag/ | Open source | https://github.com/microsoft/graphrag | Memory Tool | Graph, Vector |
+| Prometheus | Open-source monitoring system and time-series database | https://prometheus.io/ | Open source | https://github.com/prometheus | Memory Tool | Graph |
+| HybridAGI | Programmable neuro-symbolic agent framework with graph-based memory | https://synalinks.github.io/documentation/ | Open source | https://github.com/SynaLinks/HybridAGI | Memory Tool | Graph, Vector |
+| txtai | All-in-one embeddings database for semantic search, LLM orchestration, and RAG | https://neuml.github.io/txtai/ | Open source | https://github.com/neuml/txtai | Memory Tool | Vector |
+| Vanna.AI | Open-source text-to-SQL framework using RAG over your database schema | https://vanna.ai/ | Open source | https://github.com/vanna-ai/vanna | Memory Tool | Vector |
+| MemClaw | Persistent, project-isolated memory for AI coding agents, with a web dashboard | https://memclaw.me | Open source | https://github.com/Felo-Inc/memclaw | Memory Tool | Vector |
+| WhyHowAI | Knowledge-graph tooling for structuring RAG and agent memory | https://www.whyhow.ai/ | Closed | https://github.com/whyhow-ai | Memory Tool | Graph |
+| Graphlit | Managed knowledge API for content ingestion, RAG, and agents | https://graphlit.com | Closed | | Memory Tool | Graph, Vector |
+| ragie.ai | Managed RAG-as-a-service for ingesting and retrieving documents | https://ragie.ai | Closed | https://github.com/ragieai | Memory Tool | Vector |
+| Ontotext | Enterprise knowledge-graph platform (GraphDB) for RDF and semantic data | https://www.ontotext.com/ | Closed | https://github.com/Ontotext-AD | Memory Tool | Graph |
+| SID | | https://www.sid.ai/ | Closed | | Memory Tool | Vector |
+| Prometheux | Explainable reasoning / ontology engine over large knowledge graphs (Vadalog) | https://www.prometheux.co.uk/ | Closed | | Memory Tool, Storage | Vector |
+| AllegroGraph | Graph database supporting RDF, knowledge graphs, and vectors | https://allegrograph.com/ | Closed | | Memory Tool | Graph |
+| llongterm | | https://www.llongterm.com/ | Closed | | Memory Tool | Graph |
+
+## LLM frameworks
+
+| Name | Description | URL | Open / Close | GitHub URL | Category | Storage |
+|------|-------------|-----|--------------|------------|----------|---------|
+| Llama index | Data framework for connecting LLMs to your data (RAG) | https://www.llamaindex.ai/ | Managed, Open source | https://github.com/run-llama/llama_index | LLM Framework | Graph, Vector |
+| LangChain | Framework for building LLM applications and agents | https://www.langchain.com/ | Open source | https://github.com/langchain-ai/langchain | LLM Framework | Vector |
+| Haystack | Open-source framework (deepset) for RAG and search pipelines | https://haystack.deepset.ai/ | Open source | https://github.com/deepset-ai | LLM Framework | Vector |
+| PraisonAI | Multi-agent framework for building and orchestrating AI agents | https://docs.praison.ai/ | Open source | https://github.com/MervinPraison/PraisonAI | LLM Framework | Graph, Vector |
+| Rasa | Open-source framework for conversational assistants | https://rasa.com/ | Open source | https://github.com/RasaHQ/ | LLM Framework | Graph, Vector |
+
+## Optimizers
+
+| Name | Description | URL | Open / Close | GitHub URL | Category | Storage |
+|------|-------------|-----|--------------|------------|----------|---------|
+| DSPy | Framework for programming and optimizing LLM prompts and pipelines (Stanford NLP) | https://dspy.ai/ | Open source | https://github.com/stanfordnlp/dspy | Optimizer | Vector |
+| Jina AI | Multimodal AI framework for neural search and embeddings | https://jina.ai/ | Open source | https://github.com/jina-ai | Optimizer | Vector |
+
+## Storage
+
+| Name | Description | URL | Open / Close | GitHub URL | Category | Storage |
+|------|-------------|-----|--------------|------------|----------|---------|
+| Neo4j | Graph database | https://neo4j.com/ | Managed, Open source | https://github.com/neo4j | Storage | Graph |
+| FalkorDB | Low-latency graph database for GraphRAG and AI workloads | https://www.falkordb.com/ | Open source | https://github.com/FalkorDB/falkordb | Storage | Graph |
+| chroma | Open-source embedding (vector) database | https://www.trychroma.com/ | Open source | https://github.com/chroma-core/chroma | Storage | Vector |
+| Weaviate | Open-source vector database | https://weaviate.io | Open source | https://github.com/weaviate/weaviate | Storage | Vector |
+| Milvus | Open-source vector database | https://milvus.io | Open source | https://github.com/milvus-io/milvus | Storage | Vector |
+| Qdrant | Open-source vector database / similarity search engine | https://qdrant.tech | Open source | https://github.com/qdrant/qdrant | Storage | Vector |
+| Faiss | Library for efficient similarity search of dense vectors (Meta) | https://faiss.ai/ | Open source | https://github.com/facebookresearch/faiss | Storage | Vector |
+| Elasticsearch | Search and analytics engine with vector search | https://www.elastic.co/elasticsearch | Open source | https://github.com/elastic/elasticsearch | Storage | Vector |
+| NebulaGraph | Distributed open-source graph database | https://www.nebula-graph.io/ | Open source | https://github.com/vesoft-inc/nebula | Storage | Graph |
+| Neon | Serverless Postgres (supports pgvector for embeddings) | https://neon.tech/ | Open source | https://github.com/neondatabase/neon | Storage | Vector |
+| vectara | Managed RAG / retrieval platform | https://www.vectara.com/ | Closed | | Storage | Vector |
+| arcus | | https://arcus.co | Closed | | Storage | Vector |
+| Oxford Semantic Technologies | RDFox in-memory knowledge graph and reasoning engine | https://www.oxfordsemantic.tech/ | Closed | | Storage | Graph |
+| Pinecone | Managed vector database | https://pinecone.io | Closed | | Storage | Vector |
+| StarDog | Enterprise knowledge graph platform | https://www.stardog.com/ | Closed | | Storage | Graph |
+| supabase | Open-source Postgres backend (supports pgvector for embeddings) | https://supabase.com/ | Open source | https://github.com/supabase | Storage | Vector |
+
+## Benchmarks & evaluation
+ 
+Common benchmarks used to compare AI memory systems on long-term recall and reasoning:
+ 
+| Benchmark | What it measures | Link |
+|-----------|------------------|------|
+| LoCoMo | Very long-term conversational memory (QA, event summarization, multimodal dialogue) over ~300-turn, multi-session conversations | [arxiv.org/abs/2402.17753](https://arxiv.org/abs/2402.17753) · [snap-research/locomo](https://github.com/snap-research/locomo) |
+| LongMemEval | Long-term interactive memory across five abilities: information extraction, multi-session reasoning, temporal reasoning, knowledge updates, and abstention | [arxiv.org/abs/2410.10813](https://arxiv.org/abs/2410.10813) |
+ 
+Memory tools often report scores on these (and on additional benchmarks such as ConvoMem and BEAM) — see each project's own README for current numbers.
+
+## Contributing
+
+There might be many more companies and projects we aren't aware of. Your feedback and contributions are appreciated! ❤️
+
+To add a project, please open a pull request including its name, URL, source model (Open source / Managed / Closed), GitHub URL (if any), category, and storage model (Graph / Vector / Graph, Vector).
+
+## Cite this list
+ 
+If this list is useful for your work, please cite it:
+ 
+```bibtex
+@misc{awesome-ai-memory,
+  title        = {Awesome AI Memory},
+  author       = {topoteretes},
+  year         = {2026},
+  howpublished = {\url{https://github.com/topoteretes/awesome-ai-memory}}
+}
+```


### PR DESCRIPTION
Reorganizes the README for readability, no projects added or removed; all 47 entries keep their original URLs, categories, and storage values.

- Split the single flat table into four sections (Memory tools, LLM frameworks, Optimizers, Storage) with an anchored Table of Contents
- Added sections: How to use this list, Types of AI memory, Benchmarks & evaluation, Contributing, and Cite this list
- Added a one-line Description for each project
- Normalized bare-domain URLs to full https:// links
- Closed an unclosed <h5> tag that was center-aligning the intro; kept the title, badges, and infographic

