### PR TITLE
Add LWC agent memory tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,7 @@ Implementations differ mainly in how they store and retrieve this memory: **vect
 | txtai | All-in-one embeddings database for semantic search, LLM orchestration, and RAG | https://neuml.github.io/txtai/ | Open source | https://github.com/neuml/txtai | Memory Tool | Vector |
 | Vanna.AI | Open-source text-to-SQL framework using RAG over your database schema | https://vanna.ai/ | Open source | https://github.com/vanna-ai/vanna | Memory Tool | Vector |
 | MemClaw | Persistent, project-isolated memory for AI coding agents, with a web dashboard | https://memclaw.me | Open source | https://github.com/Felo-Inc/memclaw | Memory Tool | Vector |
+| LWC | Local-first proactive memory CLI for AI coding agents; maintains a source-grounded SQLite Wiki with optional document-graph and CodeGraph projections | https://janyork.github.io/llm-wiki-cli/ | Open source | https://github.com/JanYork/llm-wiki-cli | Memory Tool | Graph |
 | WhyHowAI | Knowledge-graph tooling for structuring RAG and agent memory | https://www.whyhow.ai/ | Closed | https://github.com/whyhow-ai | Memory Tool | Graph |
 | Graphlit | Managed knowledge API for content ingestion, RAG, and agents | https://graphlit.com | Closed | | Memory Tool | Graph, Vector |
 | ragie.ai | Managed RAG-as-a-service for ingesting and retrieving documents | https://ragie.ai | Closed | https://github.com/ragieai | Memory Tool | Vector |


### PR DESCRIPTION
## Summary

Add LWC to the Memory tools table with the requested project metadata.

LWC is an open-source, local-first proactive memory CLI for AI coding agents. It keeps source-grounded knowledge in a SQLite-backed Wiki and can project that memory into a document graph alongside a separate CodeGraph index.

## Classification

- Source model: Open source
- Category: Memory Tool
- Storage: Graph

The Graph classification reflects LWC's document-graph and CodeGraph capabilities; its canonical durable store remains SQLite as stated in the description.

## Validation

- [x] Project and documentation URLs return HTTP 200
- [x] No existing LWC entry
- [x] `git diff --check`
