### PR TITLE
Add inspeximus to Memory tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,6 +148,7 @@ Implementations differ mainly in how they store and retrieve this memory: **vect
 | Prometheux | Explainable reasoning / ontology engine over large knowledge graphs (Vadalog) | https://www.prometheux.co.uk/ | Closed | | Memory Tool, Storage | Vector |
 | AllegroGraph | Graph database supporting RDF, knowledge graphs, and vectors | https://allegrograph.com/ | Closed | | Memory Tool | Graph |
 | llongterm | | https://www.llongterm.com/ | Closed | | Memory Tool | Graph |
+| inspeximus | Self-correcting agent memory: a correction retires the old value by key, revert() undoes the correction on command, and every write leaves a verifiable receipt. No LLM in the loop | https://dancenitra.github.io/inspeximus/ | Open source | https://github.com/DanceNitra/inspeximus | Memory Tool | JSON file, Vector optional |
 
 ## LLM frameworks
 


### PR DESCRIPTION
Adding inspeximus under Memory tools, with the fields the Contributing section asks for.

- **Name:** inspeximus
- **URL:** https://dancenitra.github.io/inspeximus/
- **Source model:** Open source (MIT, no hosted tier)
- **GitHub URL:** https://github.com/DanceNitra/inspeximus
- **Category:** Memory Tool
- **Storage model:** JSON file, Vector optional

One note on that last field, since it does not fit the Graph / Vector / Graph, Vector options. The default store is a single JSON file with lexical recall and no dependencies; an embedder is opt-in, so a reader who assumes a vector database would be wrong either way I filled it. Happy to change it to whatever keeps the column consistent.

What it is for: a fact that gets corrected. `remember(key=...)` retires the previous value for that key rather than adding a competing one, `revert(key)` puts it back on command, and `history(key)` shows the chain. No model is asked to arbitrate, so the same inputs give the same stored state.

Measured against systems already on this list, each in its own native configuration: after a correction, recall returns the new value and not the old one in 20/20 trials here, 1/20 for mem0 and 0/20 for Hindsight 0.9.2, with 0 model calls against their 60. Method, the cells where we do not win, and the runnable harness are in [probes/INTEGRITY_BENCHMARK.md](https://github.com/DanceNitra/inspeximus/blob/main/probes/INTEGRITY_BENCHMARK.md). The first row needs no API key:

```
python probes/integrity_bench_store_resolves.py --systems inspeximus
```

Thanks for keeping this list; the Types of AI memory section is the clearest short summary of the space I have found.
